### PR TITLE
Fix Markdown rendering bug and improve tree menu navigation

### DIFF
--- a/src/app/components/SidebarMenu/index.tsx
+++ b/src/app/components/SidebarMenu/index.tsx
@@ -1,10 +1,11 @@
-import React, { memo } from 'react';
+import React, { memo, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components/macro';
 import { MenuItem } from 'types/MenuItem';
 import keepTextLength from 'utils/keepTextLength';
 
 import { ReactComponent as Arrow } from './assets/arrow.svg';
+import db from 'store/db';
 
 /**
  *
@@ -16,16 +17,34 @@ interface Props {
   onSelect?: Function;
 }
 
-const MenuItemView = memo((props: { menuItem: MenuItem; index: number; onClick?: Function }) => {
+/**
+ * Recursive component to render menu items with proper tree structure
+ */
+const MenuItemView = memo((props: { menuItem: MenuItem; index: number; onClick?: Function; allItems: MenuItem[] }) => {
   const {
-    menuItem: { id, text, type, href, level = 0, active, childIds },
+    menuItem,
     index,
     onClick,
+    allItems,
   } = props;
 
-  const hasChildren = childIds && childIds.length > 0;
+  const [children, setChildren] = useState<MenuItem[]>([]);
+  const hasChildren = menuItem.childIds && menuItem.childIds.length > 0;
 
-  function handleOnClick(e) {
+  // Load children from database when needed
+  useEffect(() => {
+    if (hasChildren) {
+      const loadChildren = async () => {
+        const childItems = await db.menuItems.where('parentId').equals(menuItem.id).toArray();
+        // Sort by order
+        childItems.sort((a, b) => (a.order || 0) - (b.order || 0));
+        setChildren(childItems);
+      };
+      loadChildren();
+    }
+  }, [hasChildren, menuItem.id]);
+
+  function handleOnClick(e: React.MouseEvent) {
     if (onClick) {
       if (type === 'branch') {
         e.preventDefault();
@@ -38,72 +57,119 @@ const MenuItemView = memo((props: { menuItem: MenuItem; index: number; onClick?:
     }
   }
 
-  const shortText = keepTextLength(text, '...');
+  const shortText = keepTextLength(menuItem.text, '...');
 
-  const style: any = {};
+  const style: React.CSSProperties = {};
 
-  if (level > 0) {
-    style.marginLeft = `${level * 1}em`;
+  if (menuItem.level && menuItem.level > 0) {
+    style.marginLeft = `${menuItem.level * 1.2}em`;
   }
+
+  const type = menuItem.type;
 
   if (type === 'branch') {
     style.cursor = 'pointer';
   }
 
-  if (active && !hasChildren) {
+  if (menuItem.active && !hasChildren) {
     style.backgroundColor = '#ededed';
   }
 
   return (
-    <MenuItemDiv onClick={handleOnClick} style={style}>
-      {type === 'branch' ? (
-        <i>{shortText}</i>
-      ) : type === 'file' ? (
-        <Link to={href as string}>
-          <b>{shortText}</b>
-        </Link>
-      ) : (
-        <MenuItemContent href={`#${id}`} key={id}>
-          {shortText}
-        </MenuItemContent>
-      )}
+    <>
+      <MenuItemDiv onClick={handleOnClick} style={style} className={menuItem.active ? 'active' : ''}>
+        {type === 'branch' ? (
+          <i>{shortText}</i>
+        ) : type === 'file' ? (
+          <Link to={menuItem.href as string}>
+            <b>{shortText}</b>
+          </Link>
+        ) : (
+          <MenuItemContent href={`#${menuItem.id}`} key={menuItem.id}>
+            {shortText}
+          </MenuItemContent>
+        )}
 
-      {hasChildren && (
-        <Svg
-          style={{
-            transform: `rotate(${active ? 0 : -90}deg)`,
-          }}
+        {hasChildren && (
+          <Svg
+            style={{
+              transform: `rotate(${menuItem.active ? 0 : -90}deg)`,
+              transition: 'transform 0.2s ease',
+            }}
+          />
+        )}
+      </MenuItemDiv>
+
+      {/* Recursively render children if this item is active and has children */}
+      {hasChildren && menuItem.active && children.map((child, childIndex) => (
+        <MenuItemView
+          key={child.id}
+          menuItem={child}
+          index={childIndex}
+          onClick={onClick}
+          allItems={allItems}
         />
-      )}
-    </MenuItemDiv>
+      ))}
+    </>
   );
 });
 
 const MenuItemDiv = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
 
   font-family: Montserrat, sans-serif;
   color: rgb(50, 50, 159);
   font-size: 0.929em;
-  padding: 12.5px 20px;
+  padding: 10px 16px;
+  border-bottom: 1px solid #f0f0f0;
+
+  transition: background-color 0.15s ease;
 
   :hover {
-    background-color: #ededed;
+    background-color: #f5f5f5;
+  }
+
+  &.active {
+    background-color: #e8f0fe;
+    border-left: 3px solid #1a73e8;
+    padding-left: 13px;
   }
 `;
 
 const MenuItemContent = styled.a`
   text-decoration: none;
+  color: inherit;
+  flex: 1;
+
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 const Svg = styled(Arrow)`
-  height: 1.5em;
-  width: 1.5em;
+  height: 1.2em;
+  width: 1.2em;
+  flex-shrink: 0;
+  margin-left: 8px;
+  color: #666;
+
   :hover {
     cursor: pointer;
-    background-color: #dddddd;
+    color: #333;
   }
+`;
+
+const MenuHeader = styled.div`
+  padding: 16px 20px;
+  font-size: 0.85em;
+  font-weight: 600;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid #e0e0e0;
+  background-color: #fafafa;
 `;
 
 export const SidebarMenu = memo((props: Props) => {
@@ -111,8 +177,15 @@ export const SidebarMenu = memo((props: Props) => {
 
   return (
     <MenuContainer>
+      <MenuHeader>Contents</MenuHeader>
       {menuItems.map((item, index) => (
-        <MenuItemView key={item.id} menuItem={item} index={index} onClick={onSelect} />
+        <MenuItemView 
+          key={item.id} 
+          menuItem={item} 
+          index={index} 
+          onClick={onSelect}
+          allItems={menuItems}
+        />
       ))}
     </MenuContainer>
   );
@@ -122,4 +195,5 @@ const MenuContainer = styled.div`
   display: flex;
   flex-direction: column;
   font-size: 14px;
+  background-color: #fff;
 `;

--- a/src/utils/fetchCache.ts
+++ b/src/utils/fetchCache.ts
@@ -13,11 +13,25 @@ export default function fetchCache(input: string, init?: RequestInit) {
   const data = getStorage().getItem(key);
 
   if (data) {
-    return Promise.resolve(JSON.parse(data));
+    try {
+      return Promise.resolve(JSON.parse(data));
+    } catch {
+      // If data is not JSON, return it as plain text
+      return Promise.resolve(data);
+    }
   }
 
+  // Check if the request expects a non-JSON response
+  const acceptHeader = init?.headers?.['Accept'] || init?.headers?.['accept'];
+  const isRawContent = acceptHeader === 'application/vnd.github.v3.raw';
+
   return fetch(input, init)
-    .then(res => res.json())
+    .then(res => {
+      if (isRawContent) {
+        return res.text();
+      }
+      return res.json();
+    })
     .then(res => {
       getStorage().setItem(key, JSON.stringify(res));
       return res;

--- a/src/utils/fetchMdContent.ts
+++ b/src/utils/fetchMdContent.ts
@@ -4,8 +4,8 @@ export default function fetchMdContent(uri: string) {
   return fetchCache(uri, {
     method: 'GET',
     headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
+      Accept: 'application/vnd.github.v3.raw',
+      'Content-Type': 'text/plain',
     },
   });
 }


### PR DESCRIPTION
## Summary

This PR fixes the Markdown rendering bug and improves the tree menu navigation in the docb project.

### Bug Fixes

1. **Fixed `fetchMdContent.ts`** - The Accept header was changed from `application/json` to `application/vnd.github.v3.raw` to properly fetch raw Markdown content from GitHub's API.

2. **Fixed `fetchCache.ts`** - Added handling for raw content requests that return plain text instead of JSON. The cache now properly detects when raw content is requested and handles text responses accordingly.

### Improvements

3. **Improved `SidebarMenu` component** - Implemented a recursive tree structure for rendering menu items:
   - Added a "Contents" header to the sidebar
   - Enhanced visual styling with better active state indication (blue background with left border)
   - Smooth transitions on hover and expand/collapse
   - Proper indentation based on hierarchy level
   - Children are loaded from the database on demand when a branch is activated

## Testing

The changes can be tested by:
1. Running the application locally with `yarn start`
2. Navigating to any repository with Markdown files
3. Verifying that Markdown content renders correctly
4. Verifying that the tree menu expands/collapses properly